### PR TITLE
Fallback to bridge in secrets file if host cannot be queried

### DIFF
--- a/src/BridgeFinder.ts
+++ b/src/BridgeFinder.ts
@@ -169,14 +169,24 @@ export class BridgeFinder extends (EventEmitter as new () => TypedEmitter<Bridge
         }
 
         let bridgeID;
-        const hostname = await this.getHostnameFromIP(ipaddr);
-        logDebug('got hostname from IP:', hostname);
+        let hostname;
+
         try {
+            hostname = await this.getHostnameFromIP(ipaddr);
+            logDebug('got hostname from IP:', hostname);
+
             // If the format of the hub hostname changes, this match can break,
             // and will appear as your credentials not working any longer
             bridgeID = hostname!.match(/[Ll]utron-(?<id>\w+)\.local/)!.groups!.id;
         } catch {
-            bridgeID = ipaddr.replace('.', '_');
+            logDebug("got exception looking up hostname");
+            if (hostname) {
+                bridgeID = ipaddr.replace('.', '_');
+            } else if (this.secrets.size == 1) {
+                // If there is only one hub then we can get the bridge value from the
+                // secrets
+                bridgeID = this.secrets.entries().next().value[0];
+            }
         }
         logDebug('extracted bridge ID:', bridgeID);
 

--- a/src/BridgeFinder.ts
+++ b/src/BridgeFinder.ts
@@ -108,7 +108,7 @@ export class BridgeFinder extends (EventEmitter as new () => TypedEmitter<Bridge
                     bridgeID = ipaddr.replace('.', '_');
                 }
                 else {
-                    throw new Error('could not extract bridge id from ip adderss');
+                    throw new Error('could not extract bridge id from ip address');
                 }
             }
             return bridgeID;


### PR DESCRIPTION

Love the plugin, thanks for your work on it. 

For some reason my network can find the Lutron device's IP address but cannot successfully query the hostname via MDNS. I only have a single bridge. In this case since the map of secrets has the bridgeId as a key we can fall back to that instead. Thought this might be useful to others.
