### PR TITLE
Fix crash when socket is closed

### DIFF
--- a/src/LeapClient.ts
+++ b/src/LeapClient.ts
@@ -197,7 +197,7 @@ export class LeapClient extends (EventEmitter as new () => TypedEmitter<LeapClie
 
             this.connected = null;
             this._empty();
-            sock.emit('disconnected');
+            this.emit('disconnected');
         };
 
         this.socket?.on('error', socketErr);


### PR DESCRIPTION
Thanks so much for all your work on this library! It's enabled me to spin up a RadioRA3 integration way faster than I'd have thought possible. :)

I discovered this small bug when my process ran for a long time and the processor closed the socket:

```
client socket has closed.
/Users/monitron/src/lutron-leap-js/dist/LeapClient.js:134
            sock.emit('disconnected');
                 ^

TypeError: sock.emit is not a function
    at TLSSocket.socketClose (/Users/monitron/src/lutron-leap-js/dist/LeapClient.js:134:18)
    at TLSSocket.emit (events.js:326:22)
    at net.js:675:12
    at TCP.done (_tls_wrap.js:568:7)
```

I think this is the fix, and if not, I hope the report helps!