### PR TITLE
Add support for MultipleZoneDefinition message

### DIFF
--- a/src/MessageBodyTypes.ts
+++ b/src/MessageBodyTypes.ts
@@ -26,6 +26,7 @@ export type MessageBodyType =
     | 'OneDeviceDefinition'
     | 'MultipleDeviceDefinition'
     | 'OneZoneDefinition'
+    | 'MultipleZoneDefinition'
     | 'OneZoneStatus'
     | 'MultipleZoneStatus'
     | 'OnePingResponse'
@@ -78,6 +79,10 @@ export class MultipleAreaDefinition {
 
 export class OneZoneDefinition {
     Zone!: ZoneDefinition;
+}
+
+export class MultipleZoneDefinition {
+    Zones: ZoneDefinition[] = [];
 }
 
 export class OneProjectDefinition {
@@ -147,6 +152,7 @@ export type BodyType =
     | MultipleLinkNodeDefinition
     | MultipleLinkDefinition
     | OneZoneDefinition
+    | MultipleZoneDefinition
     | OneAreaDefinition
     | MultipleAreaDefinition
     | OneControlStationDefinition
@@ -210,6 +216,9 @@ export function parseBody(type: MessageBodyType, data: object): BodyType {
             break;
         case 'OneZoneDefinition':
             theType = OneZoneDefinition;
+            break;
+        case 'MultipleZoneDefinition':
+            theType = MultipleZoneDefinition;
             break;
         case 'OneAreaDefinition':
             theType = OneAreaDefinition;

--- a/src/Messages.test.ts
+++ b/src/Messages.test.ts
@@ -149,17 +149,6 @@ test('OneZoneDefinition', () => {
     expect(response.Body.Zone.ControlType).toEqual('Switched');
 });
 
-test('OneZoneDefinition', () => {
-    const line =
-        '{"CommuniqueType":"ReadResponse","Header":{"MessageBodyType":"OneZoneDefinition","StatusCode":"200 OK","Url":"/zone/622","ClientTag":"ec1ec311-1e53-439d-ac46-0908252d7d08"},"Body":{"Zone":{"href":"/zone/622","Name":"Loft Outdoors","ControlType":"Switched","Category":{"Type":"OtherAmbient","IsLight":true},"AssociatedArea":{"href":"/area/729"},"SortOrder":0}}}';
-
-    const response: Response = Response.fromJSON(JSON.parse(line));
-    expect(response?.Header.StatusCode?.code).toEqual(200);
-    expect(response?.CommuniqueType).toEqual('ReadResponse');
-    // @ts-ignore
-    expect(response.Body.Zone.ControlType).toEqual('Switched');
-});
-
 test('OneAreaDefinition', () => {
     const line =
         '{"CommuniqueType":"ReadResponse","Header":{"MessageBodyType":"OneAreaDefinition","StatusCode":"200 OK","Url":"/area/729","ClientTag":"2ac306b1-13f3-4d11-a4d7-b5b4776311f3"},"Body":{"Area":{"href":"/area/729","Name":"Loft","Parent":{"href":"/area/24"},"AssociatedZones":[{"href":"/zone/622"}],"AssociatedControlStations":[{"href":"/controlstation/613"},{"href":"/controlstation/750"}]}}}';

--- a/src/Messages.test.ts
+++ b/src/Messages.test.ts
@@ -149,6 +149,17 @@ test('OneZoneDefinition', () => {
     expect(response.Body.Zone.ControlType).toEqual('Switched');
 });
 
+test('OneZoneDefinition', () => {
+    const line =
+        '{"CommuniqueType":"ReadResponse","Header":{"MessageBodyType":"OneZoneDefinition","StatusCode":"200 OK","Url":"/zone/622","ClientTag":"ec1ec311-1e53-439d-ac46-0908252d7d08"},"Body":{"Zone":{"href":"/zone/622","Name":"Loft Outdoors","ControlType":"Switched","Category":{"Type":"OtherAmbient","IsLight":true},"AssociatedArea":{"href":"/area/729"},"SortOrder":0}}}';
+
+    const response: Response = Response.fromJSON(JSON.parse(line));
+    expect(response?.Header.StatusCode?.code).toEqual(200);
+    expect(response?.CommuniqueType).toEqual('ReadResponse');
+    // @ts-ignore
+    expect(response.Body.Zone.ControlType).toEqual('Switched');
+});
+
 test('OneAreaDefinition', () => {
     const line =
         '{"CommuniqueType":"ReadResponse","Header":{"MessageBodyType":"OneAreaDefinition","StatusCode":"200 OK","Url":"/area/729","ClientTag":"2ac306b1-13f3-4d11-a4d7-b5b4776311f3"},"Body":{"Area":{"href":"/area/729","Name":"Loft","Parent":{"href":"/area/24"},"AssociatedZones":[{"href":"/zone/622"}],"AssociatedControlStations":[{"href":"/controlstation/613"},{"href":"/controlstation/750"}]}}}';
@@ -213,4 +224,15 @@ test('OnePresetDefinition', () => {
     expect(response?.CommuniqueType).toEqual('ReadResponse');
     // @ts-ignore
     expect(response.Body.Preset.Parent).toEqual({ href: '/areascene/734' });
+});
+
+test('MultipleZoneDefinition', () => {
+    const line =
+        '{"Header":{"MessageBodyType":"MultipleZoneDefinition","StatusCode":"200 OK","Url":"/area/447/associatedzone","ClientTag":"9fea5607-2959-43bc-aa89-4d5d1c573725"},"CommuniqueType":"ReadResponse","Body":{"Zones":[{"href":"/zone/823","Name":"Kitchen Lights","ControlType":"Dimmed","Category":{"Type":"","IsLight":true},"AssociatedArea":{"href":"/area/447"},"SortOrder":0}]}}';
+
+    const response: Response = Response.fromJSON(JSON.parse(line));
+    expect(response?.Header.StatusCode?.code).toEqual(200);
+    expect(response?.CommuniqueType).toEqual('ReadResponse');
+    // @ts-ignore
+    expect(response.Body.Zones[0].ControlType).toEqual('Dimmed');
 });


### PR DESCRIPTION
It's me again, back with one more small improvement. This adds support for the `MultipleZoneDefinition` message returned by a read against `/area/*/associatedzone` on a RadioRA 3 processor. Included is a test on a real-world message.

Thanks again so much for this invaluable library!!