### PR TITLE
separate words & error

### DIFF
--- a/src/LeapClient.ts
+++ b/src/LeapClient.ts
@@ -147,9 +147,9 @@ export class LeapClient extends (EventEmitter as new () => TypedEmitter<LeapClie
         let timeout;
         this.socket?.write(msg + '\n', () => {
             timeout = setTimeout(() => {
-                requestReject(new Error('request with tag' + tag + 'timed out'));
+                requestReject(new Error('request with tag ' + tag + ' timed out'));
             }, 5000);
-            logDebug('sent request tag', tag, ' successfully');
+            logDebug('sent request tag ', tag, ' successfully');
 
             this.inFlightRequests.set(tag!, {
                 message,
@@ -157,7 +157,7 @@ export class LeapClient extends (EventEmitter as new () => TypedEmitter<LeapClie
                 reject: requestReject,
                 timeout,
             });
-            logDebug('added promise to inFlightRequests with tag key', tag);
+            logDebug('added promise to inFlightRequests with tag key ', tag);
         });
         return requestPromise;
     }


### PR DESCRIPTION
```Error: request with tagc33b7b88-dcf7-4fe0-b936-1d016773f0ectimed out```

This error comes from the below error and as you can tell the tag is not operated by the words on the left and words on the right


```

[5/21/2024, 2:19:18 AM] [Lutron] Bridge 027273B9 exit reconfiguration Error: request with tagc33b7b88-dcf7-4fe0-b936-1d016773f0ectimed out
    at Timeout._onTimeout (/usr/local/lib/node_modules/homebridge-lutron-caseta-leap/node_modules/lutron-leap/src/LeapClient.ts:150:31)
    at listOnTimeout (node:internal/timers:573:17)
    at processTimers (node:internal/timers:514:7)
```