### PR TITLE
QSX support pt2

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The SmartBridge class abstractions for relevant operations like subscribing to k
 
 ## Real-world testing
 
-This library has been extensively tested on Caseta Smart Bridge 2 (pro and non-pro) devices, and gracious contributors have tested it with RA3. If you have used it elsewhere, please drop a note and let me know. So far, this library has been tested with:
+This library has been extensively tested on Caseta Smart Bridge 2 (pro and non-pro) devices, and gracious contributors have tested it with RA3 and QSX processors. If you have used it elsewhere, please drop a note and let me know. So far, this library has been tested with:
 
 * Caseta Smart Bridge 2
 * Caseta Smart Bridge 2 Pro
@@ -69,6 +69,8 @@ This library has been extensively tested on Caseta Smart Bridge 2 (pro and non-p
 * Caseta occupancy sensor
 * Serena wood blinds
 * RA3 processor
+* QSX processor (HQP7-2)
+* Palladiom Keypad
 * Sunnata Dimmer
 * Sunnata switch
 * RA3 wall motion sensor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lutron-leap",
-    "version": "3.4.2",
+    "version": "3.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lutron-leap",
-            "version": "3.4.2",
+            "version": "3.5.0",
             "license": "GPL-3.0",
             "dependencies": {
                 "async-retry": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lutron-leap",
-    "version": "3.4.2",
+    "version": "3.5.0",
     "description": "A LEAP library for Lutron Caseta Smart Bridge 2 devices",
     "keywords": [
         "lutron",
@@ -9,7 +9,11 @@
         "smartbridge",
         "lutron-leap",
         "lutron-caseta",
-        "lutron-smart-bridge"
+        "lutron-smart-bridge",
+        "qsx",
+        "lutron-qsx",
+        "hwqs",
+        "ra3"
     ],
     "homepage": "https://github.com/thenewwazoo/lutron-leap-js",
     "license": "GPL-3.0",

--- a/src/LeapClient.ts
+++ b/src/LeapClient.ts
@@ -277,6 +277,7 @@ export class LeapClient extends (EventEmitter as new () => TypedEmitter<LeapClie
 
     private _handleResponse(response: Response): void {
         const tag = response.Header.ClientTag;
+
         if (tag !== undefined) {
             logDebug('got response to tag', tag);
             const arrow: MessageDetails = this.inFlightRequests.get(tag)!;

--- a/src/Messages.test.ts
+++ b/src/Messages.test.ts
@@ -270,3 +270,42 @@ test('UndefinedPresetThings', () => {
     expect(body.Preset.FanSpeedAssignments).toBeUndefined();
     expect(body.Preset.PresetAssignments.length).toEqual(1);
 });
+
+test('QSX OneProjectDefinition', () => {
+    const line =
+        '{"CommuniqueType":"ReadResponse","Header":{"MessageBodyType":"OneProjectDefinition","StatusCode":"200 OK","Url":"/project"},"Body":{"Project":{"href":"/project","Name":"Smith, John - My Home","ProductType":"Lutron HWQS Project","MasterDeviceList":{"Devices":[{"href":"/device/2175"}]},"Contacts":[{"href":"/contactinfo/89"}],"TimeclockEventRules":{"href":"/project/timeclockeventrules"},"ProjectModifiedTimestamp":{"Year":2025,"Month":12,"Day":3,"Hour":6,"Minute":10,"Second":47,"Utc":"0"}}}}';
+
+    const response: Response = Response.fromJSON(JSON.parse(line));
+    expect(response?.Header.StatusCode?.code).toEqual(200);
+    expect(response?.CommuniqueType).toEqual('ReadResponse');
+    // @ts-ignore
+    expect(response.Body.Project.ProductType).toEqual('Lutron HWQS Project');
+    // @ts-ignore
+    expect(response.Body.Project.Name).toEqual('Smith, John - My Home');
+});
+
+test('QSX HWQSProcessor Device', () => {
+    const line =
+        '{"CommuniqueType":"ReadResponse","Header":{"MessageBodyType":"OneDeviceDefinition","StatusCode":"200 OK","Url":"/device/2175"},"Body":{"Device":{"Name":"Enclosure Device 002","DeviceType":"HWQSProcessor","AssociatedArea":{"href":"/area/741"},"href":"/device/2175","SerialNumber":91708442,"Parent":{"href":"/project"},"ModelNumber":"HQP7-2","FirmwareImage":{"Firmware":{"DisplayName":"25.09.16f000"},"Installed":{"Year":2025,"Month":12,"Day":4,"Hour":2,"Minute":11,"Second":23,"Utc":"-8:00:00"}},"AddressedState":"Addressed","IsThisDevice":true}}}';
+
+    const response: Response = Response.fromJSON(JSON.parse(line));
+    expect(response?.Header.StatusCode?.code).toEqual(200);
+    // @ts-ignore
+    expect(response.Body.Device.DeviceType).toEqual('HWQSProcessor');
+    // @ts-ignore
+    expect(response.Body.Device.ModelNumber).toEqual('HQP7-2');
+    // @ts-ignore
+    expect(response.Body.Device.IsThisDevice).toEqual(true);
+});
+
+test('QSX PalladiomKeypad Device', () => {
+    const line =
+        '{"CommuniqueType":"ReadResponse","Header":{"MessageBodyType":"OneDeviceDefinition","StatusCode":"200 OK","Url":"/device/2670"},"Body":{"Device":{"Name":"Bottom of Stairs","DeviceType":"PalladiomKeypad","AssociatedArea":{"href":"/area/729"},"href":"/device/2670","SerialNumber":53987004,"Parent":{"href":"/project"},"ModelNumber":"HQWT-U-P4W","FirmwareImage":{"href":"/firmwareimage/2670","Device":{"href":"/device/2670"}},"AddressedState":"Addressed","AssociatedLink":{"href":"/link/2370"}}}}';
+
+    const response: Response = Response.fromJSON(JSON.parse(line));
+    expect(response?.Header.StatusCode?.code).toEqual(200);
+    // @ts-ignore
+    expect(response.Body.Device.DeviceType).toEqual('PalladiomKeypad');
+    // @ts-ignore
+    expect(response.Body.Device.ModelNumber).toEqual('HQWT-U-P4W');
+});

--- a/src/SmartBridge.ts
+++ b/src/SmartBridge.ts
@@ -24,9 +24,54 @@ import TypedEmitter from 'typed-emitter';
 const logDebug = debug('leap:bridge');
 
 export const LEAP_PORT = 8081;
+
+// QSX Synthetic Button Generation
+// Since QSX processors don't expose buttons via the LEAP API, we generate
+// synthetic button definitions based on known device types.
+// The button hrefs are computed from the button group ID.
+const QSX_DEVICE_BUTTON_CONFIGS: Record<string, { count: number; startIndex: number }> = {
+    // Palladiom keypads - typically 4-6 buttons
+    PalladiomKeypad: { count: 6, startIndex: 0 },
+    // SeeTouch tabletop keypads - typically have 10-17 buttons
+    SeeTouchTabletopKeypad: { count: 17, startIndex: 0 },
+    // Generic keypad fallback
+    Keypad: { count: 6, startIndex: 0 },
+    // SeeTouch wall keypads
+    SeeTouchKeypad: { count: 6, startIndex: 0 },
+    // Hybrid keypads
+    HybridKeypad: { count: 6, startIndex: 0 },
+};
 const PING_INTERVAL_MS = 300000;
 const PING_TIMEOUT_MS = 10000;
 const CONNECT_MAX_RETRY = 20;
+
+// Global semaphore to limit concurrent button probing across all devices
+// This prevents overwhelming QSX processors during startup
+const MAX_CONCURRENT_PROBES = 2;
+let activeProbes = 0;
+const probeQueue: Array<() => void> = [];
+
+async function acquireProbeSlot(): Promise<void> {
+    if (activeProbes < MAX_CONCURRENT_PROBES) {
+        activeProbes++;
+        return;
+    }
+    // Wait for a slot to become available
+    return new Promise((resolve) => {
+        probeQueue.push(() => {
+            activeProbes++;
+            resolve();
+        });
+    });
+}
+
+function releaseProbeSlot(): void {
+    activeProbes--;
+    const next = probeQueue.shift();
+    if (next) {
+        next();
+    }
+}
 
 export interface BridgeInfo {
     firmwareRevision: string;
@@ -44,6 +89,15 @@ type SmartBridgeEvents = {
 export class SmartBridge extends (EventEmitter as new () => TypedEmitter<SmartBridgeEvents>) {
     private pingLooper: ReturnType<typeof setInterval> | null = null;
     public bridgeReconfigInProgress: boolean;
+
+    // Cache for device buttons - maps device href to all buttons on that device
+    private deviceButtonCache: Map<string, ButtonDefinition[]> = new Map();
+
+    // Track the highest button ID found per device for sequential probing
+    private deviceHighestButtonId: Map<string, number> = new Map();
+
+    // Whether QSX-specific global subscriptions have been set up
+    private qsxSubscriptionsActive = false;
 
     constructor(public readonly bridgeID: string, public client: LeapClient) {
         super();
@@ -76,6 +130,16 @@ export class SmartBridge extends (EventEmitter as new () => TypedEmitter<SmartBr
         // Send disconnect signal for re-subscribing
         this.emit('disconnected');
         this.startPingLoop();
+
+        // Re-subscribe to global button events if QSX was previously detected
+        if (this.qsxSubscriptionsActive) {
+            this.subscribeToAllButtons((r) => {
+                this._handleUnsolicited(r);
+            }).catch(() => {
+                // Subscription setup may fail on some processors
+            });
+        }
+
         this.bridgeReconfigInProgress = false;
     }
     private startPingLoop(): void {
@@ -175,17 +239,21 @@ export class SmartBridge extends (EventEmitter as new () => TypedEmitter<SmartBr
 
         // 1. Try standard /device list
         let standardDevices: DeviceDefinition[] = [];
+        let gotNoContent = false;
+        let deviceRequestFailed = false;
         try {
             const raw = await this.client.request('ReadRequest', '/device');
 
-            // Check if we got a 204 NoContent response (common with QSX)
+            // Check if we got a 204 NoContent response (indicates QSX processor)
             if (raw.Header.StatusCode?.code === 204) {
                 logDebug('Got 204 NoContent, device list is empty or not supported on this processor');
+                gotNoContent = true;
             } else if ((raw.Body! as MultipleDeviceDefinition).Devices) {
                 standardDevices = (raw.Body! as MultipleDeviceDefinition).Devices;
             }
         } catch (e) {
             logDebug('Standard /device request failed or returned empty. Proceeding to QSX check.');
+            deviceRequestFailed = true;
         }
 
         // 2. Map for Deduplication
@@ -195,11 +263,24 @@ export class SmartBridge extends (EventEmitter as new () => TypedEmitter<SmartBr
         }
 
         // 3. QSX Check
-        // If the list is empty or small, we assume it's QSX (or a fresh bridge) and crawl.
-        if (standardDevices.length <= 5) {
+        // Only crawl for QSX devices when the /device endpoint returned 204 NoContent
+        // (reliable QSX indicator) or failed entirely. A small Caseta installation
+        // with few devices should NOT trigger this crawl.
+        if (gotNoContent || (deviceRequestFailed && standardDevices.length === 0)) {
+            logDebug('QSX processor detected, crawling areas for device discovery');
             const qsxDevices = await this.discoverQSXDevices();
             for (const d of qsxDevices) {
                 deviceMap.set(d.href, d);
+            }
+
+            // Subscribe to global button/area events for QSX processors
+            if (!this.qsxSubscriptionsActive) {
+                this.qsxSubscriptionsActive = true;
+                this.subscribeToAllButtons((r) => {
+                    this._handleUnsolicited(r);
+                }).catch(() => {
+                    logDebug('Global button/area subscription failed');
+                });
             }
         }
 
@@ -232,15 +313,69 @@ export class SmartBridge extends (EventEmitter as new () => TypedEmitter<SmartBr
     public async getButtonGroupsFromDevice(
         device: DeviceDefinition,
     ): Promise<(ButtonGroupDefinition | ExceptionDetail)[]> {
-        // If ButtonGroups is missing (common on QSX crawled devices),
-        // return an empty list immediately to prevent the .map() crash.
-        if (!device.ButtonGroups) {
-            return Promise.resolve([]);
+        // If ButtonGroups exists and has entries, use them directly
+        if (device.ButtonGroups && device.ButtonGroups.length > 0) {
+            return Promise.all(
+                device.ButtonGroups.map((bgHref: Href) =>
+                    this.client.request('ReadRequest', bgHref.href).then((resp: Response) => {
+                        switch (resp.CommuniqueType) {
+                            case 'ExceptionResponse':
+                                return resp.Body! as ExceptionDetail;
+                            case 'ReadResponse':
+                                return (resp.Body! as OneButtonGroupDefinition).ButtonGroup;
+                            default:
+                                throw new Error('Unexpected communique type');
+                        }
+                    }),
+                ),
+            );
         }
 
+        // For QSX devices, ButtonGroups may not be in the device definition.
+        // Try querying the device's buttongroup endpoint directly.
+        logDebug(`No ButtonGroups on device ${device.href}, trying direct query...`);
+        try {
+            const bgResp = await this.client.request('ReadRequest', `${device.href}/buttongroup`);
+            if (bgResp.Header.StatusCode?.code === 204) {
+                logDebug(`Device ${device.href} has no button groups (204)`);
+                return [];
+            }
+            // @ts-ignore - ButtonGroups response structure
+            const buttonGroupRefs = bgResp.Body?.ButtonGroups || [];
+            if (buttonGroupRefs.length > 0) {
+                logDebug(`Found ${buttonGroupRefs.length} button group refs via direct query for ${device.href}`);
+                // Fetch each button group individually to get full details including Buttons array
+                return Promise.all(
+                    buttonGroupRefs.map((bgRef: Href) =>
+                        this.client.request('ReadRequest', bgRef.href).then((resp: Response) => {
+                            switch (resp.CommuniqueType) {
+                                case 'ExceptionResponse':
+                                    return resp.Body! as ExceptionDetail;
+                                case 'ReadResponse':
+                                    return (resp.Body! as OneButtonGroupDefinition).ButtonGroup;
+                                default:
+                                    throw new Error('Unexpected communique type');
+                            }
+                        }),
+                    ),
+                );
+            }
+        } catch (e) {
+            logDebug(`Direct buttongroup query failed for ${device.href}: ${e}`);
+        }
+
+        return [];
+    }
+
+    /**
+     * Fetch button groups by their hrefs directly.
+     * Used for merged devices (e.g., 2-gang keypads) where button groups
+     * come from multiple physical devices.
+     */
+    public async getButtonGroupsByHrefs(hrefs: string[]): Promise<(ButtonGroupDefinition | ExceptionDetail)[]> {
         return Promise.all(
-            device.ButtonGroups.map((bgHref: Href) =>
-                this.client.request('ReadRequest', bgHref.href).then((resp: Response) => {
+            hrefs.map((href: string) =>
+                this.client.request('ReadRequest', href).then((resp: Response) => {
                     switch (resp.CommuniqueType) {
                         case 'ExceptionResponse':
                             return resp.Body! as ExceptionDetail;
@@ -254,22 +389,476 @@ export class SmartBridge extends (EventEmitter as new () => TypedEmitter<SmartBr
         );
     }
 
+    /**
+     * Fetch button groups from a device href (not a device object).
+     * Used for merged devices where we only have the device hrefs.
+     * This queries the device's /buttongroup endpoint directly.
+     */
+    public async getButtonGroupsFromDeviceHref(
+        deviceHref: string,
+    ): Promise<(ButtonGroupDefinition | ExceptionDetail)[]> {
+        logDebug(`Fetching button groups from device href: ${deviceHref}`);
+        try {
+            const bgResp = await this.client.request('ReadRequest', `${deviceHref}/buttongroup`);
+            if (bgResp.Header.StatusCode?.code === 204) {
+                logDebug(`Device ${deviceHref} has no button groups (204)`);
+                return [];
+            }
+            // @ts-ignore - ButtonGroups response structure
+            const buttonGroupRefs = bgResp.Body?.ButtonGroups || [];
+            if (buttonGroupRefs.length > 0) {
+                logDebug(`Found ${buttonGroupRefs.length} button group refs for ${deviceHref}`);
+                // Fetch each button group individually to get full details including Buttons array
+                return Promise.all(
+                    buttonGroupRefs.map((bgRef: Href) =>
+                        this.client.request('ReadRequest', bgRef.href).then((resp: Response) => {
+                            switch (resp.CommuniqueType) {
+                                case 'ExceptionResponse':
+                                    return resp.Body! as ExceptionDetail;
+                                case 'ReadResponse':
+                                    return (resp.Body! as OneButtonGroupDefinition).ButtonGroup;
+                                default:
+                                    throw new Error('Unexpected communique type');
+                            }
+                        }),
+                    ),
+                );
+            }
+        } catch (e) {
+            logDebug(`Direct buttongroup query failed for ${deviceHref}: ${e}`);
+        }
+
+        return [];
+    }
+
+    /**
+     * Fetch all buttons from a device and cache them.
+     * This is used to discover buttons for QSX devices where probing near
+     * buttongroup IDs fails because buttons are sequentially numbered across
+     * the entire device, not near each buttongroup.
+     */
+    private async getAllButtonsFromDevice(deviceHref: string): Promise<ButtonDefinition[]> {
+        // Check cache first
+        if (this.deviceButtonCache.has(deviceHref)) {
+            return this.deviceButtonCache.get(deviceHref)!;
+        }
+
+        const buttons: ButtonDefinition[] = [];
+
+        try {
+            // Try the device's /button endpoint
+            const deviceButtonResp = await this.client.request('ReadRequest', `${deviceHref}/button`);
+            if (deviceButtonResp.Header.StatusCode?.code === 200) {
+                // @ts-ignore - Buttons response structure
+                const buttonRefs = deviceButtonResp.Body?.Buttons || [];
+
+                if (buttonRefs.length > 0) {
+                    // Fetch each button in parallel
+                    const buttonPromises = buttonRefs.map((btn: Href) =>
+                        this.client
+                            .request('ReadRequest', btn.href)
+                            .then((resp) => {
+                                if (resp.Header.StatusCode?.code === 200 && resp.Body) {
+                                    return (resp.Body as OneButtonDefinition).Button;
+                                }
+                                return null;
+                            })
+                            .catch(() => null),
+                    );
+                    const fetchedButtons = await Promise.all(buttonPromises);
+                    const validButtons = fetchedButtons.filter((b): b is ButtonDefinition => b !== null);
+                    buttons.push(...validButtons);
+                }
+            }
+        } catch (e) {
+            logDebug(`Failed to fetch buttons from device ${deviceHref}: ${e}`);
+        }
+
+        // Cache the result (even if empty, to avoid repeated queries)
+        this.deviceButtonCache.set(deviceHref, buttons);
+        return buttons;
+    }
+
+    /**
+     * Pre-populate the button cache for multiple device hrefs.
+     * This is useful for merged devices (2-gang keypads) where buttons
+     * might be spread across multiple physical devices.
+     */
+    public async prePopulateButtonCacheForDevices(deviceHrefs: string[]): Promise<void> {
+        await Promise.all(deviceHrefs.map((href) => this.getAllButtonsFromDevice(href)));
+    }
+
+    /**
+     * Search ALL cached buttons (across all devices) for buttons belonging to a buttongroup.
+     * This is a fallback for merged devices where the buttongroup's Parent.href might point
+     * to a different device than where the buttons actually are.
+     */
+    private searchAllCachedButtonsForGroup(buttonGroupHref: string): ButtonDefinition[] {
+        const matchingButtons: ButtonDefinition[] = [];
+        for (const [, buttons] of this.deviceButtonCache.entries()) {
+            const groupButtons = buttons.filter((btn) => btn.Parent?.href === buttonGroupHref);
+            if (groupButtons.length > 0) {
+                matchingButtons.push(...groupButtons);
+            }
+        }
+        return matchingButtons;
+    }
+
     /* Similar to getButtonGroupsFromDevice, a ButtonGroup contains a list of
      * Button Hrefs. This maps them to (promises for) the actual Button
      * objects themselves.
+     *
+     * For QSX processors that don't expose buttons via the Buttons array,
+     * we try to discover them via the button group's /button endpoint.
      */
     public async getButtonsFromGroup(bgroup: ButtonGroupDefinition): Promise<ButtonDefinition[]> {
-        return Promise.all(
-            bgroup.Buttons.map((button: Href) =>
-                this.client
-                    .request('ReadRequest', button.href)
-                    .then((resp: Response) => (resp.Body! as OneButtonDefinition).Button),
-            ),
-        );
+        // If Buttons array exists and has entries, use it directly (Caseta/RA3 path)
+        if (bgroup.Buttons && bgroup.Buttons.length > 0) {
+            return Promise.all(
+                bgroup.Buttons.map((button: Href) =>
+                    this.client
+                        .request('ReadRequest', button.href)
+                        .then((resp: Response) => (resp.Body! as OneButtonDefinition).Button),
+                ),
+            );
+        }
+
+        // For QSX: Try to discover buttons via the button group's /button endpoint
+        try {
+            const buttonResp = await this.client.request('ReadRequest', `${bgroup.href}/button`);
+            if (buttonResp.Header.StatusCode?.code === 200) {
+                // @ts-ignore - Buttons response structure
+                const buttonRefs = buttonResp.Body?.Buttons || [];
+                if (buttonRefs.length > 0) {
+                    return Promise.all(
+                        buttonRefs.map((button: Href) =>
+                            this.client
+                                .request('ReadRequest', button.href)
+                                .then((resp: Response) => (resp.Body! as OneButtonDefinition).Button),
+                        ),
+                    );
+                }
+            }
+        } catch (e) {
+            logDebug(`Button discovery via ${bgroup.href}/button failed: ${e}`);
+        }
+
+        // QSX Strategy: Try to get all buttons from the parent device and filter by buttongroup
+        // This works when buttons are sequentially numbered across the device, not near each buttongroup ID
+        // @ts-ignore
+        const parentDeviceHref = bgroup.Parent?.href as string | undefined;
+
+        // Keep track of buttons found from cache - we'll augment with probing results
+        let cachedGroupButtons: ButtonDefinition[] = [];
+
+        if (parentDeviceHref) {
+            const allDeviceButtons = await this.getAllButtonsFromDevice(parentDeviceHref);
+
+            if (allDeviceButtons.length > 0) {
+                // Filter to buttons that belong to this buttongroup
+                cachedGroupButtons = allDeviceButtons.filter((btn) => btn.Parent?.href === bgroup.href);
+
+                // Update highest known button ID from cache
+                if (cachedGroupButtons.length > 0) {
+                    const maxButtonId = Math.max(
+                        ...cachedGroupButtons.map((b) => parseInt(b.href.split('/').pop() || '0', 10)),
+                    );
+                    const currentHighest = this.deviceHighestButtonId.get(parentDeviceHref) || 0;
+                    if (maxButtonId > currentHighest) {
+                        this.deviceHighestButtonId.set(parentDeviceHref, maxButtonId);
+                    }
+                }
+                // DON'T return here - continue to probe for additional buttons not in cache
+            }
+        }
+
+        // Fallback for merged devices: Search ALL cached buttons across all devices
+        // This handles cases where a buttongroup's Parent.href points to one device,
+        // but the buttons are actually on another device in the merged set
+        if (cachedGroupButtons.length === 0) {
+            const allCachedButtons = this.searchAllCachedButtonsForGroup(bgroup.href);
+            if (allCachedButtons.length > 0) {
+                cachedGroupButtons = allCachedButtons;
+            }
+        }
+
+        // Fallback: Try to query individual buttons near the button group ID
+        // On QSX, button hrefs are often close to the button group ID
+        const buttonGroupId = parseInt(bgroup.href.split('/').pop() || '0', 10);
+        const parentDeviceId = parseInt((parentDeviceHref || '').split('/').pop() || '0', 10);
+
+        // Check if we have a highest known button ID for this device
+        // Buttons are often sequential across all buttongroups on a device
+        const highestKnownButtonId = parentDeviceHref ? this.deviceHighestButtonId.get(parentDeviceHref) : undefined;
+
+        // Acquire semaphore slot to limit concurrent probing across all devices
+        await acquireProbeSlot();
+
+        // Helper function to probe a range of button IDs
+        const probeButtonRange = async (baseId: number, _label: string): Promise<ButtonDefinition[]> => {
+            const BATCH_SIZE = 3;
+            const BATCH_DELAY_MS = 200;
+            const discoveredButtons: ButtonDefinition[] = [];
+            let emptyBatchCount = 0;
+
+            for (let batchStart = 1; batchStart <= 20; batchStart += BATCH_SIZE) {
+                const batchPromises: Promise<ButtonDefinition | null>[] = [];
+
+                for (let offset = batchStart; offset < batchStart + BATCH_SIZE && offset <= 20; offset++) {
+                    const buttonHref = `/button/${baseId + offset}`;
+                    batchPromises.push(
+                        this.client
+                            .request('ReadRequest', buttonHref)
+                            .then((resp) => {
+                                if (resp.Header.StatusCode?.code === 200 && resp.Body) {
+                                    const button = (resp.Body as OneButtonDefinition).Button;
+                                    if (button && button.Parent?.href === bgroup.href) {
+                                        return button;
+                                    }
+                                }
+                                return null;
+                            })
+                            .catch(() => null),
+                    );
+                }
+
+                const batchResults = await Promise.all(batchPromises);
+                const foundInBatch = batchResults.filter((b): b is ButtonDefinition => b !== null);
+                discoveredButtons.push(...foundInBatch);
+
+                if (foundInBatch.length === 0) {
+                    emptyBatchCount++;
+                    // Only stop early if we've found at least 3 buttons AND had 3 consecutive empty batches
+                    if (discoveredButtons.length >= 3 && emptyBatchCount >= 3) {
+                        break;
+                    }
+                } else {
+                    emptyBatchCount = 0;
+                }
+
+                // Small delay between batches to let QSX recover
+                if (batchStart + BATCH_SIZE <= 20) {
+                    await new Promise((resolve) => setTimeout(resolve, BATCH_DELAY_MS));
+                }
+            }
+            return discoveredButtons;
+        };
+
+        // Declared outside try block so we can merge with cached buttons after
+        let discoveredButtons: ButtonDefinition[] = [];
+
+        try {
+            // Priority 1: If we have a highest known button ID for this device,
+            // try probing from there first (buttons are often sequential across buttongroups)
+            if (highestKnownButtonId && highestKnownButtonId > 0) {
+                discoveredButtons = await probeButtonRange(highestKnownButtonId, 'sequential');
+            }
+
+            // Priority 2: Try probing near the button group ID
+            if (discoveredButtons.length === 0) {
+                discoveredButtons = await probeButtonRange(buttonGroupId, 'buttongroup');
+            }
+
+            // Priority 3: If no buttons found and device ID is different, try probing near device ID
+            if (discoveredButtons.length === 0 && parentDeviceId > 0 && parentDeviceId !== buttonGroupId) {
+                discoveredButtons = await probeButtonRange(parentDeviceId, 'device');
+            }
+
+            // Priority 4: Try querying the parent device's /button endpoint directly
+            if (discoveredButtons.length === 0 && parentDeviceId > 0) {
+                try {
+                    const deviceButtonResp = await this.client.request(
+                        'ReadRequest',
+                        `/device/${parentDeviceId}/button`,
+                    );
+                    if (deviceButtonResp.Header.StatusCode?.code === 200) {
+                        // @ts-ignore - Buttons response structure
+                        const buttonRefs = deviceButtonResp.Body?.Buttons || [];
+                        if (buttonRefs.length > 0) {
+                            // Fetch each button and filter to those belonging to this button group
+                            const buttonPromises = buttonRefs.map((btn: Href) =>
+                                this.client
+                                    .request('ReadRequest', btn.href)
+                                    .then((resp) => {
+                                        if (resp.Header.StatusCode?.code === 200 && resp.Body) {
+                                            const button = (resp.Body as OneButtonDefinition).Button;
+                                            // Only include buttons that belong to THIS button group
+                                            if (button && button.Parent?.href === bgroup.href) {
+                                                return button;
+                                            }
+                                        }
+                                        return null;
+                                    })
+                                    .catch(() => null),
+                            );
+                            const buttons = await Promise.all(buttonPromises);
+                            discoveredButtons = buttons.filter((b): b is ButtonDefinition => b !== null);
+                        }
+                    }
+                } catch (e) {
+                    logDebug(`Device /button endpoint failed for device ${parentDeviceId}: ${e}`);
+                }
+            }
+
+            // Priority 5: If we found buttons, continue probing from the highest one found
+            // Loop until we stop finding new buttons (handles devices with many sequential buttons)
+            if (discoveredButtons.length > 0) {
+                let lastMaxId = Math.max(...discoveredButtons.map((b) => parseInt(b.href.split('/').pop() || '0', 10)));
+                let continuationRound = 0;
+                const MAX_CONTINUATION_ROUNDS = 10; // Safety limit
+
+                while (continuationRound < MAX_CONTINUATION_ROUNDS) {
+                    continuationRound++;
+                    const additionalButtons = await probeButtonRange(lastMaxId, `continuation-${continuationRound}`);
+
+                    if (additionalButtons.length === 0) {
+                        break;
+                    }
+
+                    // Merge with discovered buttons (deduplicate)
+                    let newButtonsAdded = 0;
+                    for (const btn of additionalButtons) {
+                        if (!discoveredButtons.some((b) => b.href === btn.href)) {
+                            discoveredButtons.push(btn);
+                            newButtonsAdded++;
+                        }
+                    }
+
+                    if (newButtonsAdded === 0) {
+                        break;
+                    }
+
+                    // Update lastMaxId for next round
+                    lastMaxId = Math.max(...discoveredButtons.map((b) => parseInt(b.href.split('/').pop() || '0', 10)));
+                }
+            }
+
+            if (discoveredButtons.length > 0) {
+                // Update the highest known button ID for this device
+                if (parentDeviceHref) {
+                    const maxButtonId = Math.max(
+                        ...discoveredButtons.map((b) => parseInt(b.href.split('/').pop() || '0', 10)),
+                    );
+                    const currentHighest = this.deviceHighestButtonId.get(parentDeviceHref) || 0;
+                    if (maxButtonId > currentHighest) {
+                        this.deviceHighestButtonId.set(parentDeviceHref, maxButtonId);
+                    }
+
+                    // Also add to device button cache for future buttongroups
+                    const cached = this.deviceButtonCache.get(parentDeviceHref) || [];
+                    const newButtons = discoveredButtons.filter((b) => !cached.some((c) => c.href === b.href));
+                    if (newButtons.length > 0) {
+                        this.deviceButtonCache.set(parentDeviceHref, [...cached, ...newButtons]);
+                    }
+                }
+            }
+        } catch (e) {
+            logDebug(`Probing failed for button group ${buttonGroupId}: ${e}`);
+        }
+
+        // Release semaphore before merging/returning (doesn't need throttling)
+        releaseProbeSlot();
+
+        // Merge cached buttons with probed buttons (deduplicate by href)
+        const allButtons = [...cachedGroupButtons];
+        for (const probedBtn of discoveredButtons) {
+            if (!allButtons.some((b) => b.href === probedBtn.href)) {
+                allButtons.push(probedBtn);
+            }
+        }
+
+        if (allButtons.length > 0) {
+            return allButtons;
+        }
+
+        // Last resort: Generate synthetic buttons
+        // @ts-ignore
+        const syntheticDeviceHref = bgroup.Parent?.href;
+        if (syntheticDeviceHref) {
+            // Fetch the parent device to get its type
+            let deviceType = 'Unknown';
+            try {
+                const deviceResp = await this.client.request('ReadRequest', syntheticDeviceHref);
+                deviceType = (deviceResp.Body as OneDeviceDefinition)?.Device?.DeviceType || 'Unknown';
+            } catch (e) {
+                logDebug(`Failed to fetch parent device: ${e}`);
+            }
+
+            // Check if this device type supports synthetic button generation
+            let buttonConfig = QSX_DEVICE_BUTTON_CONFIGS[deviceType];
+
+            // If no exact match, check for partial matches (e.g., "SomeNewKeypad" contains "Keypad")
+            if (!buttonConfig) {
+                for (const [key, config] of Object.entries(QSX_DEVICE_BUTTON_CONFIGS)) {
+                    if (deviceType.includes(key)) {
+                        buttonConfig = config;
+                        break;
+                    }
+                }
+            }
+
+            if (buttonConfig) {
+                // Generate synthetic buttons
+                const syntheticButtons: ButtonDefinition[] = [];
+
+                for (let i = 0; i < buttonConfig.count; i++) {
+                    const buttonNumber = buttonConfig.startIndex + i;
+                    const buttonId = buttonGroupId * 100 + buttonNumber;
+                    const buttonHref = `/button/${buttonId}`;
+
+                    syntheticButtons.push({
+                        href: buttonHref,
+                        ButtonNumber: buttonNumber,
+                        Name: `Button ${buttonNumber + 1}`,
+                        // @ts-ignore - Adding parent reference for debugging
+                        Parent: { href: bgroup.href },
+                        // @ts-ignore - Mark as synthetic for debugging
+                        _synthetic: true,
+                    } as unknown as ButtonDefinition);
+                }
+
+                return syntheticButtons;
+            }
+        }
+
+        return [];
     }
 
     public subscribeToButton(button: ButtonDefinition, cb: (r: Response) => void) {
+        // @ts-ignore - Check if this is a synthetic button
+        if (button._synthetic) {
+            // QSX processors don't support button/buttongroup status subscriptions.
+            // Button presses on QSX keypads trigger scene changes instead of button events.
+            // We handle this via area status subscriptions in subscribeToAllButtons().
+            return;
+        }
         this.client.subscribe(button.href + '/status/event', cb);
+    }
+
+    /**
+     * Subscribe to all button events globally.
+     * This may be required on QSX to enable button event streaming.
+     * We try multiple endpoints since QSX may use different event paths.
+     *
+     * On QSX, keypads don't emit button events - they trigger scene changes.
+     * We subscribe to /area/status to capture these scene activations.
+     */
+    public async subscribeToAllButtons(cb: (r: Response) => void): Promise<void> {
+        // Try multiple endpoints - QSX may deliver button events differently
+        const endpoints = [
+            '/button/status', // Works on Caseta/RA3
+            '/area/status', // QSX keypads trigger scene changes on areas
+        ];
+
+        for (const endpoint of endpoints) {
+            try {
+                await this.client.subscribe(endpoint, (r) => {
+                    cb(r);
+                });
+            } catch (e) {
+                logDebug(`Global ${endpoint} subscription failed: ${e}`);
+            }
+        }
     }
 
     /* Because we can't subscribe to individual occupancysensors, we have to
@@ -296,6 +885,43 @@ export class SmartBridge extends (EventEmitter as new () => TypedEmitter<SmartBr
         // nothing to do here
         logDebug('bridge id', this.bridgeID, 'disconnected.');
         this.emit('disconnected');
+    }
+
+    /**
+     * Fetch a single button by href (for dynamic discovery).
+     * Used when a button press event arrives for an unknown button.
+     */
+    public async getButton(buttonHref: string): Promise<ButtonDefinition | null> {
+        try {
+            const resp = await this.client.request('ReadRequest', buttonHref);
+            if (resp.Header.StatusCode?.code === 200 && resp.Body) {
+                return (resp.Body as OneButtonDefinition).Button;
+            }
+        } catch (e) {
+            logDebug(`Failed to fetch button ${buttonHref}: ${e}`);
+        }
+        return null;
+    }
+
+    /**
+     * Export all cached buttons for persistence.
+     * Returns a copy of the device button cache.
+     */
+    public getAllCachedButtons(): Map<string, ButtonDefinition[]> {
+        return new Map(this.deviceButtonCache);
+    }
+
+    /**
+     * Import a previously discovered button into the cache.
+     * Used to restore persisted buttons on startup.
+     */
+    public addDiscoveredButton(deviceHref: string, button: ButtonDefinition): void {
+        const existing = this.deviceButtonCache.get(deviceHref) || [];
+        if (!existing.some((b) => b.href === button.href)) {
+            existing.push(button);
+            this.deviceButtonCache.set(deviceHref, existing);
+            logDebug(`Added discovered button ${button.href} to cache for device ${deviceHref}`);
+        }
     }
 
     /**
@@ -345,7 +971,11 @@ export class SmartBridge extends (EventEmitter as new () => TypedEmitter<SmartBr
                                     const needsFullDetails =
                                         device.DeviceType === 'PlugInDimmer' ||
                                         device.DeviceType === 'WallDimmer' ||
-                                        device.DeviceType === 'PlugInSwitch';
+                                        device.DeviceType === 'PlugInSwitch' ||
+                                        device.DeviceType === 'PalladiomKeypad' ||
+                                        device.DeviceType === 'SeeTouchTabletopKeypad' ||
+                                        device.DeviceType?.includes('Keypad') ||
+                                        device.DeviceType?.includes('Pico');
 
                                     let fullDevice = device;
                                     if (needsFullDetails) {

--- a/src/SmartBridge.ts
+++ b/src/SmartBridge.ts
@@ -525,20 +525,26 @@ export class SmartBridge extends (EventEmitter as new () => TypedEmitter<SmartBr
             );
         }
 
-        // For QSX: Try to discover buttons via the button group's /button endpoint
+        // For QSX: Try to discover buttons via the button group's /button endpoint.
+        // Do NOT return early here — the QSX processor only returns the originally-programmed
+        // buttons from this endpoint; newly-added buttons are absent. We always fall through
+        // to probing so the full set is discovered.
+        let groupEndpointButtons: ButtonDefinition[] = [];
         try {
             const buttonResp = await this.client.request('ReadRequest', `${bgroup.href}/button`);
             if (buttonResp.Header.StatusCode?.code === 200) {
                 // @ts-ignore - Buttons response structure
-                const buttonRefs = buttonResp.Body?.Buttons || [];
+                const buttonRefs: Href[] = buttonResp.Body?.Buttons || [];
                 if (buttonRefs.length > 0) {
-                    return Promise.all(
-                        buttonRefs.map((button: Href) =>
-                            this.client
-                                .request('ReadRequest', button.href)
-                                .then((resp: Response) => (resp.Body! as OneButtonDefinition).Button),
-                        ),
-                    );
+                    groupEndpointButtons = (
+                        await Promise.all(
+                            buttonRefs.map((button: Href) =>
+                                this.client
+                                    .request('ReadRequest', button.href)
+                                    .then((resp: Response) => (resp.Body! as OneButtonDefinition).Button),
+                            ),
+                        )
+                    ).filter((b): b is ButtonDefinition => b != null);
                 }
             }
         } catch (e) {
@@ -550,8 +556,8 @@ export class SmartBridge extends (EventEmitter as new () => TypedEmitter<SmartBr
         // @ts-ignore
         const parentDeviceHref = bgroup.Parent?.href as string | undefined;
 
-        // Keep track of buttons found from cache - we'll augment with probing results
-        let cachedGroupButtons: ButtonDefinition[] = [];
+        // Seed with buttons returned by the group endpoint; augment with probing below
+        let cachedGroupButtons: ButtonDefinition[] = [...groupEndpointButtons];
 
         if (parentDeviceHref) {
             const allDeviceButtons = await this.getAllButtonsFromDevice(parentDeviceHref);
@@ -726,29 +732,45 @@ export class SmartBridge extends (EventEmitter as new () => TypedEmitter<SmartBr
                 }
             }
 
-            // Continuation: probe from each discovered cluster's highest ID
-            // to find any buttons that are just beyond the initial +20 window
+            // Continuation: probe from the frontier of EACH cluster of discovered buttons.
+            // Buttons on a keypad can live in disjoint ID ranges (e.g. ~3500s and ~46500s).
+            // Probing only from the global max would miss a lower cluster entirely.
             if (discoveredButtons.length > 0) {
-                let lastMaxId = Math.max(...discoveredButtons.map((b) => parseInt(b.href.split('/').pop() || '0', 10)));
+                const getClusterFrontiers = (): number[] => {
+                    const ids = discoveredButtons
+                        .map((b) => parseInt(b.href.split('/').pop() || '0', 10))
+                        .sort((a, b) => a - b);
+                    const frontiers: number[] = [];
+                    for (let i = 0; i < ids.length; i++) {
+                        // A gap of >20 between consecutive IDs means the next ID is a new cluster
+                        if (i === ids.length - 1 || ids[i + 1] - ids[i] > 20) {
+                            frontiers.push(ids[i]);
+                        }
+                    }
+                    return frontiers;
+                };
+
+                let frontiers = getClusterFrontiers();
                 let continuationRound = 0;
                 const MAX_CONTINUATION_ROUNDS = 10; // Safety limit
 
                 while (continuationRound < MAX_CONTINUATION_ROUNDS) {
                     continuationRound++;
-                    const additionalButtons = await probeButtonRange(lastMaxId, `continuation-${continuationRound}`);
+                    let anyNewFound = false;
 
-                    if (additionalButtons.length === 0) {
+                    for (const frontier of frontiers) {
+                        const additionalButtons = await probeButtonRange(frontier, `continuation-${continuationRound}`);
+                        if (additionalButtons.length > 0 && mergeButtons(additionalButtons) > 0) {
+                            anyNewFound = true;
+                        }
+                    }
+
+                    if (!anyNewFound) {
                         break;
                     }
 
-                    const newButtonsAdded = mergeButtons(additionalButtons);
-
-                    if (newButtonsAdded === 0) {
-                        break;
-                    }
-
-                    // Update lastMaxId for next round
-                    lastMaxId = Math.max(...discoveredButtons.map((b) => parseInt(b.href.split('/').pop() || '0', 10)));
+                    // Recalculate frontiers — new buttons may have extended a cluster or added one
+                    frontiers = getClusterFrontiers();
                 }
             }
 

--- a/src/SmartBridge.ts
+++ b/src/SmartBridge.ts
@@ -96,8 +96,14 @@ export class SmartBridge extends (EventEmitter as new () => TypedEmitter<SmartBr
     // Track the highest button ID found per device for sequential probing
     private deviceHighestButtonId: Map<string, number> = new Map();
 
-    // Whether QSX-specific global subscriptions have been set up
-    private qsxSubscriptionsActive = false;
+    // Whether this bridge is a QSX processor. Set during device discovery.
+    // Used by PicoRemote to select the correct button event model:
+    // QSX buttons use press-only timers (short press on timeout) because the hub
+    // may deliver Press without Release; Caseta buttons use long press timers.
+    private _isQSX = false;
+    public get isQSX(): boolean {
+        return this._isQSX;
+    }
 
     constructor(public readonly bridgeID: string, public client: LeapClient) {
         super();
@@ -106,6 +112,13 @@ export class SmartBridge extends (EventEmitter as new () => TypedEmitter<SmartBr
         client.on('unsolicited', this._handleUnsolicited.bind(this));
         client.on('disconnected', this._handleDisconnect.bind(this));
         this.startPingLoop();
+
+        // Subscribe to global button events (needed for QSX, harmless for Caseta/RA3)
+        this.subscribeToAllButtons((r) => {
+            this._handleUnsolicited(r);
+        }).catch(() => {
+            // Subscription setup may fail on some processors
+        });
     }
     public async reconfigureBridge(newClient: LeapClient) {
         this.bridgeReconfigInProgress = true;
@@ -131,14 +144,12 @@ export class SmartBridge extends (EventEmitter as new () => TypedEmitter<SmartBr
         this.emit('disconnected');
         this.startPingLoop();
 
-        // Re-subscribe to global button events if QSX was previously detected
-        if (this.qsxSubscriptionsActive) {
-            this.subscribeToAllButtons((r) => {
-                this._handleUnsolicited(r);
-            }).catch(() => {
-                // Subscription setup may fail on some processors
-            });
-        }
+        // Re-subscribe to global button events
+        this.subscribeToAllButtons((r) => {
+            this._handleUnsolicited(r);
+        }).catch(() => {
+            // Subscription setup may fail on some processors
+        });
 
         this.bridgeReconfigInProgress = false;
     }
@@ -268,19 +279,10 @@ export class SmartBridge extends (EventEmitter as new () => TypedEmitter<SmartBr
         // with few devices should NOT trigger this crawl.
         if (gotNoContent || (deviceRequestFailed && standardDevices.length === 0)) {
             logDebug('QSX processor detected, crawling areas for device discovery');
+            this._isQSX = true;
             const qsxDevices = await this.discoverQSXDevices();
             for (const d of qsxDevices) {
                 deviceMap.set(d.href, d);
-            }
-
-            // Subscribe to global button/area events for QSX processors
-            if (!this.qsxSubscriptionsActive) {
-                this.qsxSubscriptionsActive = true;
-                this.subscribeToAllButtons((r) => {
-                    this._handleUnsolicited(r);
-                }).catch(() => {
-                    logDebug('Global button/area subscription failed');
-                });
             }
         }
 

--- a/src/SmartBridge.ts
+++ b/src/SmartBridge.ts
@@ -649,24 +649,48 @@ export class SmartBridge extends (EventEmitter as new () => TypedEmitter<SmartBr
         // Declared outside try block so we can merge with cached buttons after
         let discoveredButtons: ButtonDefinition[] = [];
 
+        // Helper to merge newly found buttons into discoveredButtons, deduplicating by href
+        const mergeButtons = (newButtons: ButtonDefinition[]): number => {
+            let added = 0;
+            for (const btn of newButtons) {
+                if (!discoveredButtons.some((b) => b.href === btn.href)) {
+                    discoveredButtons.push(btn);
+                    added++;
+                }
+            }
+            return added;
+        };
+
         try {
-            // Priority 1: If we have a highest known button ID for this device,
-            // try probing from there first (buttons are often sequential across buttongroups)
+            // On QSX, buttons within a single buttongroup can be split across
+            // two distant ID ranges: some near the buttongroup ID, others near
+            // the device ID. Probe ALL ranges unconditionally and merge results.
+
+            // Range 1: Near the highest known button ID for this device
+            // (buttons are often sequential across buttongroups on a device)
             if (highestKnownButtonId && highestKnownButtonId > 0) {
-                discoveredButtons = await probeButtonRange(highestKnownButtonId, 'sequential');
+                mergeButtons(await probeButtonRange(highestKnownButtonId, 'sequential'));
             }
 
-            // Priority 2: Try probing near the button group ID
-            if (discoveredButtons.length === 0) {
-                discoveredButtons = await probeButtonRange(buttonGroupId, 'buttongroup');
+            // Range 2: Near the button group ID
+            mergeButtons(await probeButtonRange(buttonGroupId, 'buttongroup'));
+
+            // Range 3: Near the device ID
+            // On QSX, buttons in a single buttongroup can be split across two
+            // distant ID ranges (some near the buttongroup ID, some near the
+            // device ID). When the IDs are far apart, earlier ranges can't
+            // cover both, so we must probe the device range even if range 2
+            // already found buttons. When they're close (within the probe
+            // window), range 2 already covers the device vicinity.
+            const PROBE_WINDOW = 20;
+            if (parentDeviceId > 0 && parentDeviceId !== buttonGroupId) {
+                const idsAreFarApart = Math.abs(buttonGroupId - parentDeviceId) > PROBE_WINDOW;
+                if (discoveredButtons.length === 0 || idsAreFarApart) {
+                    mergeButtons(await probeButtonRange(parentDeviceId, 'device'));
+                }
             }
 
-            // Priority 3: If no buttons found and device ID is different, try probing near device ID
-            if (discoveredButtons.length === 0 && parentDeviceId > 0 && parentDeviceId !== buttonGroupId) {
-                discoveredButtons = await probeButtonRange(parentDeviceId, 'device');
-            }
-
-            // Priority 4: Try querying the parent device's /button endpoint directly
+            // Range 4: Try querying the parent device's /button endpoint directly
             if (discoveredButtons.length === 0 && parentDeviceId > 0) {
                 try {
                     const deviceButtonResp = await this.client.request(
@@ -694,7 +718,7 @@ export class SmartBridge extends (EventEmitter as new () => TypedEmitter<SmartBr
                                     .catch(() => null),
                             );
                             const buttons = await Promise.all(buttonPromises);
-                            discoveredButtons = buttons.filter((b): b is ButtonDefinition => b !== null);
+                            mergeButtons(buttons.filter((b): b is ButtonDefinition => b !== null));
                         }
                     }
                 } catch (e) {
@@ -702,8 +726,8 @@ export class SmartBridge extends (EventEmitter as new () => TypedEmitter<SmartBr
                 }
             }
 
-            // Priority 5: If we found buttons, continue probing from the highest one found
-            // Loop until we stop finding new buttons (handles devices with many sequential buttons)
+            // Continuation: probe from each discovered cluster's highest ID
+            // to find any buttons that are just beyond the initial +20 window
             if (discoveredButtons.length > 0) {
                 let lastMaxId = Math.max(...discoveredButtons.map((b) => parseInt(b.href.split('/').pop() || '0', 10)));
                 let continuationRound = 0;
@@ -717,14 +741,7 @@ export class SmartBridge extends (EventEmitter as new () => TypedEmitter<SmartBr
                         break;
                     }
 
-                    // Merge with discovered buttons (deduplicate)
-                    let newButtonsAdded = 0;
-                    for (const btn of additionalButtons) {
-                        if (!discoveredButtons.some((b) => b.href === btn.href)) {
-                            discoveredButtons.push(btn);
-                            newButtonsAdded++;
-                        }
-                    }
+                    const newButtonsAdded = mergeButtons(additionalButtons);
 
                     if (newButtonsAdded === 0) {
                         break;


### PR DESCRIPTION
## Summary

Builds on the initial QSX area-based device discovery in #35 to add full button support for QSX keypads (Palladiom, SeeTouch, etc.).

QSX processors differ from Caseta/RA3 in how they expose buttons: Caseta provides a Buttons array on each ButtonGroup, while QSX often returns empty ButtonGroup objects with no Buttons array. This required multiple new discovery strategies.

### Button discovery and probing
- Query device `/button` and buttongroup `/button` endpoints directly
- Probe sequential button IDs near buttongroup/device IDs with batched requests and a global semaphore (max 2 concurrent) to avoid overwhelming QSX processors
- Cache discovered buttons per-device for cross-buttongroup lookups
- Generate synthetic fallback buttons (marked `_synthetic`) when all probing fails, allowing downstream to distinguish real vs placeholder
- Continuation probing: after finding buttons, keep probing from the highest ID to find additional sequential buttons

### Merged device (2-gang keypad) support
- `getButtonGroupsFromDeviceHref()`: fetch button groups by device href for merged devices
- `getButtonGroupsByHrefs()`: fetch button groups by direct hrefs
- `prePopulateButtonCacheForDevices()`: bulk-cache buttons across multiple physical devices
- `searchAllCachedButtonsForGroup()`: cross-device button search for cases where a buttongroup's Parent points to a different device

### Event handling and QSX detection
- **`isQSX` public getter**: Exposes QSX detection result so the homebridge plugin can set `isPressOnlyButton` for proper button press handling
- **Unconditional global subscriptions**: `subscribeToAllButtons()` called in constructor (harmless on Caseta/RA3, required for QSX global event delivery)
- **Individual subscriptions restored**: `subscribeToButton()` no longer gated by `qsxSubscriptionsActive` — individual button subscriptions work on all processors, with 50ms deduplication preventing double-processing
- `getButton()`: fetch a single button by href for dynamic discovery
- `addDiscoveredButton()`: import persisted buttons into cache

### QSX detection improvements
- `getDeviceInfo()` gates QSX area crawl on 204 NoContent response from `/device` (reliable QSX indicator) rather than device count
- `discoverQSXDevices()` fetches full device details for keypads and Pico remotes to get ButtonGroups
- Sets `_isQSX = true` during QSX detection for downstream consumers

### Backward compatibility
- All existing Caseta/RA3 code paths preserved unchanged
- `getButtonGroupsFromDevice()` checks for empty ButtonGroups before falling back to direct endpoint queries
- `getButtonsFromGroup()` uses existing Buttons array when present
- Global subscriptions in constructor are harmless on Caseta (deduplication handles any overlap)

## Test plan

- [x] TypeScript compiles with no errors
- [x] Manual testing on HomeWorks QSX processor end-to-end with homebridge-lutron-caseta-leap