### PR TITLE
Reconnect when the keep-alive ping fails

### DIFF
--- a/src/SmartBridge.ts
+++ b/src/SmartBridge.ts
@@ -93,17 +93,24 @@ export class SmartBridge extends (EventEmitter as new () => TypedEmitter<SmartBr
                     logDebug('Ping succeeded', resp);
                 })
                 .catch((e) => {
-                    // if it fails, however, what do we do? the client's
-                    // behavior is to attempt to re-open the connection if it's
-                    // lost. that means calling `this.client.close()` might
-                    // clobber in-flight requests made between the ping timing
-                    // out and the attempt to close it. that's bad.
+                    // A failed or timed-out keep-alive ping means the LEAP
+                    // session is dead, even though the underlying TCP socket may
+                    // still look ESTABLISHED (a half-open connection, e.g. after
+                    // the bridge briefly changes address during a router reboot).
+                    // Nothing else will detect this: the socket never emits
+                    // 'close'/'error'/'end', so LeapClient never emits
+                    // 'disconnected' and the client never reconnects. The ping is
+                    // the only signal we get, so act on it.
                     //
-                    // I think the answer is: nothing. future attempts to use
-                    // the client will block (and potentially eventually time
-                    // out), and we don't ever want to prevent that happening
-                    // unless specifically requested.
-                    logDebug('Ping failed:', e);
+                    // Close the client to force recovery. `LeapClient.close()`
+                    // ends the socket, which emits 'disconnected' (triggering
+                    // re-subscription) and causes the next request to reconnect.
+                    // The previous concern about clobbering in-flight requests
+                    // does not apply here: a timed-out ping means the connection
+                    // is already dead, so any in-flight requests are already
+                    // doomed and will be retried after the reconnect.
+                    logDebug('Ping failed; closing client to force reconnect:', e);
+                    this.client.close();
                 });
         }, PING_INTERVAL_MS);
     }


### PR DESCRIPTION
## Summary

`SmartBridge` sends a keep-alive ping every 5 minutes (`PING_INTERVAL_MS`), but **when the ping fails or times out, the handler does nothing but log a debug line.** If the LEAP connection dies at the application layer while the underlying TCP socket stays open — a half-open connection, e.g. after a router/AP reboot briefly renumbers the bridge — the `SmartBridge` never recovers. Every subsequent request hangs until the host process is restarted by hand.

## Root cause

In `startPingLoop()`:

```ts
Promise.race([pingPromise, timeoutPromise])
    .then((resp) => { logDebug('Ping succeeded', resp); })
    .catch((e) => {
        // ... "I think the answer is: nothing. future attempts to use
        // the client will block ..."
        logDebug('Ping failed:', e);   // only logs; never reconnects
    });
```

The comment assumes future requests will "block and eventually time out" and thereby self-heal. But for a **half-open** socket, no `close`/`error`/`end` event ever fires, so `LeapClient` never emits `disconnected`, `_handleDisconnect` never runs, and the client never reconnects. The ping is the only signal that the session is dead — and it's discarded.

## Fix

On ping failure, call `this.client.close()`. As its own docstring notes, "subsequent requests will trigger this client to attempt to reconnect"; `close()` ends the socket, which emits `disconnected` (re-subscription) and lets the next request reconnect. The prior worry about clobbering in-flight requests doesn't apply: a timed-out ping means the connection is already dead, so those requests are already doomed and will be retried after reconnect.

## Testing / evidence

Observed on a live Caséta Smart Bridge behind a router that auto-reboots nightly. The plugin was found holding an `ESTABLISHED` socket to the correct bridge IP with empty send/recv queues, yet every HomeKit read logged `The read handler for the characteristic '…' was slow to respond` and accessories showed "No Response". The 5-minute ping timed out on every cycle but never triggered a reconnect; only a manual restart recovered it. With this change the failed ping closes the client and the next request reconnects automatically.

### Optional follow-ups (not included here)
- `PING_INTERVAL_MS = 300000` (5 min) leaves a dead session undetected for up to 5 minutes; consider lowering to 60–90s.
- A guard flag to avoid overlapping reconnects if `close()` races an in-progress reconnect.
